### PR TITLE
カレンダーを表示する機能を備えたコマンドラインプログラムを実装

### DIFF
--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -25,7 +25,7 @@ const run = () => {
 
   return [
     generateCalendarHeader(year, month),
-    generateWeekHeader(),
+    "Su Mo Tu We Th Fr Sa",
     ...generateMonthDates(year, month),
   ].join("\n");
 };
@@ -41,19 +41,16 @@ const getFirstDateOfMonth = (year, month) => {
   return new Date(year, month - 1, 1);
 };
 
-const generateWeekHeader = () => {
-  return "Su Mo Tu We Th Fr Sa";
-};
-
 const generateMonthDates = (year, month) => {
-  const dayInMonth = getLastDateOfMonth(year, month).getDate();
+  const lastDay = getLastDayOfMonth(year, month);
   const weeks = [];
   let monthDates = "";
   monthDates += generateBlankDays(year, month);
 
-  for (let day = 1; day <= dayInMonth; day++) {
+  for (let day = 1; day <= lastDay; day++) {
     monthDates += generateDayFormat(day);
-    if (isSaturday(year, month, day) || day == dayInMonth) {
+    if (isSaturday(year, month, day) || day === lastDay) {
+      monthDates = monthDates.trimEnd();
       weeks.push(monthDates);
       monthDates = "";
     }
@@ -61,8 +58,8 @@ const generateMonthDates = (year, month) => {
   return weeks;
 };
 
-const getLastDateOfMonth = (year, month) => {
-  return new Date(year, month, 0);
+const getLastDayOfMonth = (year, month) => {
+  return new Date(year, month, 0).getDate();
 };
 
 const generateBlankDays = (year, month) => {

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+import minimist from "minimist";
+
+const HEADER_WIDTH = 14;
+const DAY_WIDTH = 2;
+const BLANK_DAY = " ".repeat(3);
+const FIRST_DAY_OF_MONTH = 1;
+
+const today = new Date();
+const currentYear = today.getFullYear();
+const currentMonth = today.getMonth() + 1;
+
+const parseOptions = minimist(process.argv.slice(2), {
+  string: ["-y", "-m"],
+  alias: {
+    y: "year",
+    m: "month",
+  },
+  default: {
+    y: currentYear,
+    m: currentMonth,
+  },
+});
+
+const year = parseOptions.year;
+const month = parseOptions.month;
+
+const getFirstDateOfMonth = () => {
+  return new Date(year, month - 1, 1);
+};
+
+const getLastDateOfMonth = () => {
+  return new Date(year, month, 0);
+};
+
+const generateCalendarHeader = () => {
+  const monthName = getFirstDateOfMonth().toLocaleString("en-US", {
+    month: "short",
+  });
+  return `${monthName} ${year}`.padStart(HEADER_WIDTH, " ");
+};
+
+const generateWeekHeader = () => {
+  return "Su Mo Tu We Th Fr Sa";
+};
+
+const generateDayFormat = (day) => {
+  const dayString = day.toString().padStart(DAY_WIDTH, " ");
+  return dayString + " ";
+};
+
+const generateBlankDays = () => {
+  return BLANK_DAY.repeat(getFirstDateOfMonth().getDay());
+};
+
+const isSaturday = (year, month, day) => {
+  return new Date(year, month - 1, day).getDay() === 6;
+};
+
+const generateMonthDates = () => {
+  const dayInMonth = getLastDateOfMonth().getDate();
+  const monthDates = [];
+  monthDates.push(generateBlankDays());
+
+  for (let day = FIRST_DAY_OF_MONTH; day <= dayInMonth; day++) {
+    monthDates.push(generateDayFormat(day));
+    if (isSaturday(year, month, day)) {
+      monthDates.push("\n");
+    }
+  }
+  return monthDates.join("");
+};
+
+const run = () => {
+  return [
+    generateCalendarHeader(),
+    generateWeekHeader(),
+    generateMonthDates(),
+  ].join("\n");
+};
+
+console.log(run());

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -26,7 +26,7 @@ const run = () => {
   return [
     generateCalendarHeader(year, month),
     generateWeekHeader(),
-    generateMonthDates(year, month),
+    ...generateMonthDates(year, month),
   ].join("\n");
 };
 
@@ -47,15 +47,18 @@ const generateWeekHeader = () => {
 
 const generateMonthDates = (year, month) => {
   const dayInMonth = getLastDateOfMonth(year, month).getDate();
-  let monthDates = generateBlankDays(year, month);
+  const weeks = [];
+  let monthDates = "";
+  monthDates += generateBlankDays(year, month);
 
   for (let day = 1; day <= dayInMonth; day++) {
     monthDates += generateDayFormat(day);
-    if (isSaturday(year, month, day)) {
-      monthDates += "\n";
+    if (isSaturday(year, month, day) || day == dayInMonth) {
+      weeks.push(monthDates);
+      monthDates = "";
     }
   }
-  return monthDates;
+  return weeks;
 };
 
 const getLastDateOfMonth = (year, month) => {

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -1,50 +1,7 @@
 #!/usr/bin/env node
 import minimist from "minimist";
 
-const getFirstDateOfMonth = (year, month) => {
-  return new Date(year, month - 1, 1);
-};
-
-const getLastDateOfMonth = (year, month) => {
-  return new Date(year, month, 0);
-};
-
-const generateCalendarHeader = (year, month) => {
-  const monthName = getFirstDateOfMonth(year, month).toLocaleString("en-US", {
-    month: "short",
-  });
-  return `${monthName} ${year}`.padStart(14, " ");
-};
-
-const generateWeekHeader = () => {
-  return "Su Mo Tu We Th Fr Sa";
-};
-
-const generateDayFormat = (day) => {
-  const dayString = day.toString().padStart(2, " ");
-  return dayString + " ";
-};
-
-const generateBlankDays = (year, month) => {
-  return "   ".repeat(getFirstDateOfMonth(year, month).getDay());
-};
-
-const isSaturday = (year, month, day) => {
-  return new Date(year, month - 1, day).getDay() === 6;
-};
-
-const generateMonthDates = (year, month) => {
-  const dayInMonth = getLastDateOfMonth(year, month).getDate();
-  let monthDates = generateBlankDays(year, month);
-
-  for (let day = 1; day <= dayInMonth; day++) {
-    monthDates += generateDayFormat(day);
-    if (isSaturday(year, month, day)) {
-      monthDates += "\n";
-    }
-  }
-  return monthDates;
-};
+const HEADER_WIDTH = 14;
 
 const run = () => {
   const today = new Date();
@@ -71,6 +28,51 @@ const run = () => {
     generateWeekHeader(),
     generateMonthDates(year, month),
   ].join("\n");
+};
+
+const generateCalendarHeader = (year, month) => {
+  const monthName = getFirstDateOfMonth(year, month).toLocaleString("en-US", {
+    month: "short",
+  });
+  return `${monthName} ${year}`.padStart(HEADER_WIDTH, " ");
+};
+
+const getFirstDateOfMonth = (year, month) => {
+  return new Date(year, month - 1, 1);
+};
+
+const generateWeekHeader = () => {
+  return "Su Mo Tu We Th Fr Sa";
+};
+
+const generateMonthDates = (year, month) => {
+  const dayInMonth = getLastDateOfMonth(year, month).getDate();
+  let monthDates = generateBlankDays(year, month);
+
+  for (let day = 1; day <= dayInMonth; day++) {
+    monthDates += generateDayFormat(day);
+    if (isSaturday(year, month, day)) {
+      monthDates += "\n";
+    }
+  }
+  return monthDates;
+};;
+
+const getLastDateOfMonth = (year, month) => {
+  return new Date(year, month, 0);
+};
+
+const generateBlankDays = (year, month) => {
+  return "   ".repeat(getFirstDateOfMonth(year, month).getDay());
+};
+
+const generateDayFormat = (day) => {
+  const dayString = day.toString().padStart(2, " ");
+  return dayString + " ";
+};
+
+const isSaturday = (year, month, day) => {
+  return new Date(year, month - 1, day).getDay() === 6;
 };
 
 console.log(run());

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -50,9 +50,10 @@ const generateMonthDates = (year, month) => {
   for (let day = 1; day <= lastDay; day++) {
     monthDates += generateDayFormat(day);
     if (isSaturday(year, month, day) || day === lastDay) {
-      monthDates = monthDates.trimEnd();
       weeks.push(monthDates);
       monthDates = "";
+    } else {
+      monthDates += " ";
     }
   }
   return weeks;
@@ -67,8 +68,7 @@ const generateBlankDays = (year, month) => {
 };
 
 const generateDayFormat = (day) => {
-  const dayString = day.toString().padStart(2, " ");
-  return dayString + " ";
+  return day.toString().padStart(2, " ");
 };
 
 const isSaturday = (year, month, day) => {

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -1,43 +1,19 @@
 #!/usr/bin/env node
 import minimist from "minimist";
 
-const HEADER_WIDTH = 14;
-const DAY_WIDTH = 2;
-const BLANK_DAY = " ".repeat(3);
-const FIRST_DAY_OF_MONTH = 1;
-
-const today = new Date();
-const currentYear = today.getFullYear();
-const currentMonth = today.getMonth() + 1;
-
-const parseOptions = minimist(process.argv.slice(2), {
-  string: ["-y", "-m"],
-  alias: {
-    y: "year",
-    m: "month",
-  },
-  default: {
-    y: currentYear,
-    m: currentMonth,
-  },
-});
-
-const year = parseOptions.year;
-const month = parseOptions.month;
-
-const getFirstDateOfMonth = () => {
+const getFirstDateOfMonth = (year, month) => {
   return new Date(year, month - 1, 1);
 };
 
-const getLastDateOfMonth = () => {
+const getLastDateOfMonth = (year, month) => {
   return new Date(year, month, 0);
 };
 
-const generateCalendarHeader = () => {
-  const monthName = getFirstDateOfMonth().toLocaleString("en-US", {
+const generateCalendarHeader = (year, month) => {
+  const monthName = getFirstDateOfMonth(year, month).toLocaleString("en-US", {
     month: "short",
   });
-  return `${monthName} ${year}`.padStart(HEADER_WIDTH, " ");
+  return `${monthName} ${year}`.padStart(14, " ");
 };
 
 const generateWeekHeader = () => {
@@ -45,37 +21,55 @@ const generateWeekHeader = () => {
 };
 
 const generateDayFormat = (day) => {
-  const dayString = day.toString().padStart(DAY_WIDTH, " ");
+  const dayString = day.toString().padStart(2, " ");
   return dayString + " ";
 };
 
-const generateBlankDays = () => {
-  return BLANK_DAY.repeat(getFirstDateOfMonth().getDay());
+const generateBlankDays = (year, month) => {
+  return "   ".repeat(getFirstDateOfMonth(year, month).getDay());
 };
 
 const isSaturday = (year, month, day) => {
   return new Date(year, month - 1, day).getDay() === 6;
 };
 
-const generateMonthDates = () => {
-  const dayInMonth = getLastDateOfMonth().getDate();
-  const monthDates = [];
-  monthDates.push(generateBlankDays());
+const generateMonthDates = (year, month) => {
+  const dayInMonth = getLastDateOfMonth(year, month).getDate();
+  let monthDates = generateBlankDays(year, month);
 
-  for (let day = FIRST_DAY_OF_MONTH; day <= dayInMonth; day++) {
-    monthDates.push(generateDayFormat(day));
+  for (let day = 1; day <= dayInMonth; day++) {
+    monthDates += generateDayFormat(day);
     if (isSaturday(year, month, day)) {
-      monthDates.push("\n");
+      monthDates += "\n";
     }
   }
-  return monthDates.join("");
+  return monthDates;
 };
 
 const run = () => {
+  const today = new Date();
+  const currentYear = today.getFullYear();
+  const currentMonth = today.getMonth() + 1;
+
+  const parseOptions = minimist(process.argv.slice(2), {
+    string: ["-y", "-m"],
+    alias: {
+      y: "year",
+      m: "month",
+    },
+    default: {
+      y: currentYear,
+      m: currentMonth,
+    },
+  });
+
+  const year = parseOptions.year;
+  const month = parseOptions.month;
+
   return [
-    generateCalendarHeader(),
+    generateCalendarHeader(year, month),
     generateWeekHeader(),
-    generateMonthDates(),
+    generateMonthDates(year, month),
   ].join("\n");
 };
 

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -34,7 +34,7 @@ const generateCalendarHeader = (year, month) => {
   const monthName = getFirstDateOfMonth(year, month).toLocaleString("en-US", {
     month: "short",
   });
-  return `${monthName} ${year}`.padStart(HEADER_WIDTH, " ");
+  return `${monthName} ${year}`.padStart(HEADER_WIDTH);
 };
 
 const getFirstDateOfMonth = (year, month) => {
@@ -68,7 +68,7 @@ const generateBlankDays = (year, month) => {
 };
 
 const generateDayFormat = (day) => {
-  return day.toString().padStart(2, " ");
+  return day.toString().padStart(2);
 };
 
 const isSaturday = (year, month, day) => {

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -56,7 +56,7 @@ const generateMonthDates = (year, month) => {
     }
   }
   return monthDates;
-};;
+};
 
 const getLastDateOfMonth = (year, month) => {
   return new Date(year, month, 0);

--- a/02.calendar/package-lock.json
+++ b/02.calendar/package-lock.json
@@ -4,6 +4,9 @@
   "requires": true,
   "packages": {
     "": {
+      "dependencies": {
+        "minimist": "^1.2.8"
+      },
       "devDependencies": {
         "eslint": "^8.24.0",
         "eslint-config-prettier": "^8.5.0",
@@ -897,6 +900,14 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/ms": {
@@ -1974,6 +1985,11 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
+    },
+    "minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
     },
     "ms": {
       "version": "2.1.2",

--- a/02.calendar/package.json
+++ b/02.calendar/package.json
@@ -8,5 +8,8 @@
     "eslint-config-prettier": "^8.5.0",
     "prettier": "^2.7.1"
   },
-  "type": "module"
+  "type": "module",
+  "dependencies": {
+    "minimist": "^1.2.8"
+  }
 }


### PR DESCRIPTION
# 実装内容
コマンドラインからオプションで年月を指定してカレンダーを表示できるプログラムを実装しました。

## 主な機能
- コマンドライン引数 (-y、-m) を`minimist`により解析し、ユーザーが指定した年月のカレンダーを表示します。
- 引数を指定しない場合、自動的に現在の年月のカレンダーが表示されます。

## 注記
- 例外処理を用いたエラーハンドリングの実装は組み入れていません。
- 基本的なカレンダー表示のみのシンプルなプログラムです。

## テスト
✅ `ESLint`と`Prettier`を通過しています。
✅ 異なる年月をコマンドライン引数として渡し、カレンダーが正確に表示される事を確認しました。
✅ `1970年1月`と`2100年12月`のカレンダーが正しく表示される事を確認しました。
